### PR TITLE
Simplify game event types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7031,7 +7031,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7031,6 +7031,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/shared/types/game.ts
+++ b/src/shared/types/game.ts
@@ -73,22 +73,31 @@ export interface GameState {
     dealersUsed: Set<string>; // Track which players have been dealer
 }
 
-// Socket.IO event types
+// Base event type with common properties that all events receive
+export interface BaseEvent {
+    timestamp: number;
+    sequenceNumber: number;
+}
+
+// Helper type to add BaseEvent properties to any type
+type WithEventMetadata<T> = T & BaseEvent;
+
+// Socket.IO event types with proper typing
 export interface ServerToClientEvents {
-    gameStateUpdated: (state: GameState & { timestamp: number; sequenceNumber: number }) => void;
-    playerJoined: (player: Player & { timestamp: number; sequenceNumber: number }) => void;
-    playerLeft: (playerId: string & { timestamp: number; sequenceNumber: number }) => void;
-    errorOccurred: (message: string & { timestamp: number; sequenceNumber: number }) => void;
-    chatMessageReceived: (message: { playerId: string; text: string; timestamp: number } & { timestamp: number; sequenceNumber: number }) => void;
-    bettingPhaseStarted: (gameId: string & { timestamp: number; sequenceNumber: number }) => void;
-    playerActed: (data: { playerId: string; action: BettingAction } & { timestamp: number; sequenceNumber: number }) => void;
-    bettingPhaseCompleted: (gameId: string & { timestamp: number; sequenceNumber: number }) => void;
-    gameStarted: (gameId: string & { timestamp: number; sequenceNumber: number }) => void;
-    diceRolled: (data: { gameId: string; diceRoll: DiceRoll } & { timestamp: number; sequenceNumber: number }) => void;
-    cardsSelected: (data: { gameId: string; playerId: string } & { timestamp: number; sequenceNumber: number }) => void;
-    cardsImproved: (data: { gameId: string; playerId: string } & { timestamp: number; sequenceNumber: number }) => void;
-    roundEnded: (data: { winner: string; pot: number; tiebreakerUsed: boolean } & { timestamp: number; sequenceNumber: number }) => void;
-    gameEnded: (data: { winner: string; finalChips: number; allPlayers: { name: string; finalChips: number }[] } & { timestamp: number; sequenceNumber: number }) => void;
+    gameStateUpdated: (data: WithEventMetadata<GameState>) => void;
+    playerJoined: (data: WithEventMetadata<Player>) => void;
+    playerLeft: (data: WithEventMetadata<string>) => void;
+    errorOccurred: (data: WithEventMetadata<string>) => void;
+    chatMessageReceived: (data: WithEventMetadata<{ playerId: string; text: string; timestamp: number }>) => void;
+    bettingPhaseStarted: (data: WithEventMetadata<string>) => void;
+    playerActed: (data: WithEventMetadata<{ playerId: string; action: BettingAction }>) => void;
+    bettingPhaseCompleted: (data: WithEventMetadata<string>) => void;
+    gameStarted: (data: WithEventMetadata<string>) => void;
+    diceRolled: (data: WithEventMetadata<{ gameId: string; diceRoll: DiceRoll }>) => void;
+    cardsSelected: (data: WithEventMetadata<{ gameId: string; playerId: string }>) => void;
+    cardsImproved: (data: WithEventMetadata<{ gameId: string; playerId: string }>) => void;
+    roundEnded: (data: WithEventMetadata<{ winner: string; pot: number; tiebreakerUsed: boolean }>) => void;
+    gameEnded: (data: WithEventMetadata<{ winner: string; finalChips: number; allPlayers: { name: string; finalChips: number }[] }>) => void;
 }
 
 export interface ClientToServerEvents {


### PR DESCRIPTION
Refactor `ServerToClientEvents` in `src/shared/types/game.ts` to use a `BaseEvent` type, eliminating repetition and improving maintainability.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-92c863b4-2c3a-49ae-bd56-54eb60413d43) · [Cursor](https://cursor.com/background-agent?bcId=bc-92c863b4-2c3a-49ae-bd56-54eb60413d43)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)